### PR TITLE
Modified egg configuration to integrate better with Pterodactyl

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,35 +133,43 @@ Change the region variable to match your region
 
 - Go to Nests -> Create New
   - Enter a name
-  - Click on New Egg
-  - Associated Nest: The Nest you just created
-  - Name: Enter a name
-  - Docker Images:
-  ``miarshmallow/echovr`` (You can build and upload (dockerhub) your own Dockerimage with the provided Dockerfile if you want to.)
-  - Startup Command: ``${MODIFIED_STARTUP}``
-  - Stop Command: ``^C``
-  - Configuration Files:
-    ```
-    {
-        "server.properties": {
-            "parser": "properties",
-            "find": {
-                "server-ip": "0.0.0.0",
-                "enable-query": "true",
-                "server-port": "{{server.build.default.port}}",
-                "query.port": "{{server.build.default.port}}"
-            }
+  ## Option 1: Import premade egg
+    1. Download https://github.com/BL00DY-C0D3/pterodactyl_Echo_Server/blob/main/echovr-egg.json
+    2. Click "Import Egg"
+      - Egg file: The downloaded JSON file
+      - Associated Nest: The nest you just created
+    3. Save
+   
+  ## Option 2: Manually create egg
+    1. Click on New Egg
+    2. Associated Nest: The Nest you just created
+    3. Name: Enter a name
+    4. Docker Images:
+    ``miarshmallow/echovr`` (You can build and upload (dockerhub) your own Dockerimage with the provided Dockerfile if you want to.)
+    5. Startup Command: ``${MODIFIED_STARTUP}``
+    6. Stop Command: ``^C ^C``
+    7. Configuration Files:
+       ```
+       {
+           "server.properties": {
+               "parser": "properties",
+               "find": {
+                   "server-ip": "0.0.0.0",
+                   "enable-query": "true",
+                   "server-port": "{{server.build.default.port}}",
+                   "query.port": "{{server.build.default.port}}"
+               }
+           }
+       }
+       ```
+    8. Start Configuration:
+        ```
+        {
+          "done": "[NSLOBBY] registration successful"
         }
-    }
-    ```
-  - Start Configuration:
-      ```
-      {
-          "done": ")! For help, type "
-      }
-      ```
-  - Log Configuration: ``{}``
-- Save
+        ```
+    9. Log Configuration: ``{}``
+    10. Save
 
 # Prepare mounts
 


### PR DESCRIPTION
No major changes, but I was wanting to get the correct status (running instead of starting) once the server successfully registered. I also wanted to not have to use the "kill" button, so now it forces the server to shutdown instantly in one click. It works flawlessly otherwise, I consistently have 3 servers running using it and it is very nice.

- Modified `Start Configuration` to properly identify when the server completed the startup phase
- Modified `Stop Command` to forcefully power down the node (instead of requiring the use of "kill" or waiting for a timeout)
- Uploaded preconfigured egg file and added instructions for importing the egg instead of creating one manually.